### PR TITLE
add istio support

### DIFF
--- a/api/controllers/deploy/process.js
+++ b/api/controllers/deploy/process.js
@@ -148,6 +148,13 @@ exports.applyActionForLocation = function (reqdata, action, configloc, callback)
                     "tls": [{"hosts": [configLocation.serviceDNS]}]
                   }
                 };
+                
+                if (reqdata.annotations["sidecar.istio.io/inject"] == "true") {
+                  console.log(reqdata.key, "Adding istio annotation to ingress");
+                  kubeingress.metadata.annotations["kubernetes.io/ingress.class"] = "istio";
+                  kubeingress.spec.rules[0].http.paths[0].path = "/.*";
+                  delete kubeingress.spec.tls;
+                }
 
                 k8sHelper.k8sCRUD.ensureObject(kubeingress, kubeapiParams, 'ingresses', null, function (err, data) {
                   if (err) {


### PR DESCRIPTION
Some minor adjustments to ingress are required in order to work w/ the envoy implementation of ingress instead of the nginx inplementation. It seems that tls is also not supported currently for ingress as well so that portion is removed.