### PR TITLE
add version tag, set from container tag & allow override

### DIFF
--- a/api/controllers/deploy/k8sTypes.js
+++ b/api/controllers/deploy/k8sTypes.js
@@ -180,13 +180,14 @@ exports.setrcjson = function (reqdata) {
       break;
     }
   
-  if (reqdata.type == "deployments" || reqdata.type == "daemonsets") {
-    
+  if (_.has(reqdata, 'containers[0]')) {
+    //set version tag
+    tmpJson.spec.template.metadata.labels.version = reqdata.version;
+
     //set group selector if it exists
     if (reqdata.targetGroup != "" && reqdata.targetGroup != null) {
-      tmpJson.metareqdata.name = reqdata.name + "-" + reqdata.targetGroup;
-      tmpJson.spec.selector.group = reqdata.targetGroup;
-      tmpJson.spec.template.metareqdata.labels.group = reqdata.targetGroup;
+      kubeObjJson.metadata.name = reqdata.name + "-" + reqdata.targetGroup;
+      tmpJson.spec.template.metadata.labels.group = reqdata.targetGroup;
     }
 
     if (reqdata.imagePullSecrets != "" && reqdata.imagePullSecrets != null) {

--- a/api/controllers/deploy/validate.js
+++ b/api/controllers/deploy/validate.js
@@ -173,11 +173,14 @@ exports.validateUpdateIndex = function (reqdata, callback) {
   // get the version from the first container tag
   if (!_.has(reqdata, 'version') && _.has(reqdata, 'containers[0].image')) {
     var ver = _.split(reqdata.containers[0].image, ":", 2);
-    if (ver[1] != null && ver[1] != "") {
+    if (ver.length == 2 && ver[1] != "") {
       reqdata.version = ver[1];
     }
-  } else if (!_.has(reqdata, 'version') || reqdata.version == "") {
-    reqdata.version = Date.now();
+  }
+
+  //set version if still not set
+  if (!_.has(reqdata, 'version') || reqdata.version == "") {
+    reqdata.version = Date.now().toString();
   }
   
   if (reqdata.loadBalanced == true ||

--- a/api/controllers/deploy/validate.js
+++ b/api/controllers/deploy/validate.js
@@ -169,7 +169,16 @@ exports.validateUpdateIndex = function (reqdata, callback) {
   reqdata.deployClusters = [];
   reqdata.deleteClusters = [];
   reqdata.endpoints = {}; //setup for adding records later
-  reqdata.version = Date.now();
+
+  // get the version from the first container tag
+  if (!_.has(reqdata, 'version') && _.has(reqdata, 'containers[0].image')) {
+    var ver = _.split(reqdata.containers[0].image, ":", 2);
+    if (ver[1] != null && ver[1] != "") {
+      reqdata.version = ver[1];
+    }
+  } else if (!_.has(reqdata, 'version') || reqdata.version == "") {
+    reqdata.version = Date.now();
+  }
   
   if (reqdata.loadBalanced == true ||
       reqdata.targetPort != null) {

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -381,6 +381,9 @@ definitions:
       f5poolname:
         type: "string"
         description: "overrides the pool name created by the f5 plugin to be the value specified instead of the servicename-namespace. Creates an annotation named f5poolname."
+      version:
+        type: "string"
+        description: "override version from default of container tag or timestamp."
   objectDelParams:
     type: "object"
     required:


### PR DESCRIPTION
This adds automatic detection of the version tag for container object types, which is based off of the first container in the deployment. When not available version is set to a timestamp. `version` can also now be provided in the request as an override.