### PR TITLE
explicitly specify the deployment selector

### DIFF
--- a/api/controllers/deploy/k8sTypes.js
+++ b/api/controllers/deploy/k8sTypes.js
@@ -105,6 +105,11 @@ exports.setrcjson = function (reqdata) {
             "maxSurge": "60%"
             },
           },
+        "selector": {
+          "matchLabels": {
+            "service": reqdata.name,
+          }
+        },
         "template": {
           "metadata": {
             "labels": {


### PR DESCRIPTION
This add an explicit selector to the deployments so that additional labels on the pods do not interfere w/ deployments.