### PR TITLE
Allow canaries to be deleted by targetGroup

### DIFF
--- a/api/controllers/deploy/validate.js
+++ b/api/controllers/deploy/validate.js
@@ -96,9 +96,7 @@ exports.validateDestroy = function (reqdata, callback) {
 
   //set group selector if it exists
   if (reqdata.targetGroup != "" && reqdata.targetGroup != null) {
-    reqdata.deployment = reqdata.name + "-" + reqdata.targetGroup;
-  } else {
-    reqdata.deployment = reqdata.name;
+    reqdata.name = reqdata.name + "-" + reqdata.targetGroup;
   }
   
   setRequestKey(reqdata);


### PR DESCRIPTION
This fixes a defect where the targetGroup is ignored for `DELETE`.