### PR TITLE
add namespaces

### DIFF
--- a/api/controllers/deploy/k8sTypes.js
+++ b/api/controllers/deploy/k8sTypes.js
@@ -57,6 +57,14 @@ exports.getKind = function(type) {
         "containerSpec": true
       };
       break;
+    case 'namespaces':
+      kind = {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "prefix": "api",
+        "containerSpec": false
+      };
+      break;
     case 'secrets':
       kind = {
         "apiVersion": "v1",

--- a/api/controllers/deploy/process.js
+++ b/api/controllers/deploy/process.js
@@ -21,6 +21,10 @@ exports.applyActionForLocation = function (reqdata, action, configloc, callback)
     kubercjsonreplaced = {};
   }
   
+  if (typeof config.customLocationProcessingHandler === 'function') {
+    config.customLocationProcessingHandler(action, reqdata, configLocation, kubercjsonreplaced);
+  }
+  
   var kubeapiParams = {
     host:  splitURL[1],
     protocol: splitURL[0],
@@ -33,10 +37,6 @@ exports.applyActionForLocation = function (reqdata, action, configloc, callback)
     timeout: 20000,
     cluster: configLocation
   };
-  
-  if (typeof config.customLocationProcessingHandler === 'function') {
-    config.customLocationProcessingHandler(action, reqdata, configLocation, kubercjsonreplaced);
-  }
   
   if (action == "remove") {
     //remove only deletes service records to prevent external access

--- a/api/controllers/deploy/validate.js
+++ b/api/controllers/deploy/validate.js
@@ -225,8 +225,8 @@ exports.validateUpdateIndex = function (reqdata, callback) {
     reqdata.type = "deployments";
   }
   
-  if (!["configmaps", "daemonsets", "deployments", "destinationpolicies", "egressrules", "horizontalpodautoscalers", "ingresses", "jobs", "routerules", "secrets", "services", "statefulsets"].includes(reqdata.type)) {
-    return callback(422, 'Type must be one of: "configmaps", "daemonsets", "deployments", "destinationpolicies", "egressrules", "horizontalpodautoscalers", "ingresses", "jobs", "routerules", "secrets", "services", "statefulsets"');
+  if (!["configmaps", "daemonsets", "deployments", "destinationpolicies", "egressrules", "horizontalpodautoscalers", "ingresses", "jobs", "namespaces", "routerules", "secrets", "services", "statefulsets"].includes(reqdata.type)) {
+    return callback(422, 'Type must be one of: "configmaps", "daemonsets", "deployments", "destinationpolicies", "egressrules", "horizontalpodautoscalers", "ingresses", "jobs", "namespaces", "routerules", "secrets", "services", "statefulsets"');
   }
   
   if (reqdata.containers == null || reqdata.containers == "") {


### PR DESCRIPTION
Allows namespaces to be created through the API. 
Previously this was handled by external automation for us and as such was not required.