### PR TITLE
add init container support

### DIFF
--- a/api/controllers/deploy/k8sHelper.js
+++ b/api/controllers/deploy/k8sHelper.js
@@ -36,7 +36,8 @@ exports.addENV = function (array, value) {
   }
 }
 
-exports.handleContainerParams = function (healthCheck, containerReqdata, kubercjson) {
+exports.handleContainerParams = function (healthCheck, containerReqdata, kubercjson, type) {
+  //type == "containers" || initContainers
   //containerReqdata = reqdata.containers[i]
 
   var containerjson =
@@ -67,7 +68,7 @@ exports.handleContainerParams = function (healthCheck, containerReqdata, kubercj
   }
 
   //handle multiple ports for the container if it's an array
-  if (containerReqdata.port.constructor === Array) {
+  if (_.isArray(containerReqdata.port)) {
     for (var ports = 0; ports < containerReqdata.port.length; ports++) {
       containerjson.ports.push({"containerPort": containerReqdata.port[ports]});
     }
@@ -82,73 +83,75 @@ exports.handleContainerParams = function (healthCheck, containerReqdata, kubercj
   }
 
   //reqdata.healthCheck = "http" || "tcp" || "none"
-  if (healthCheck == "http") {
-    containerjson.livenessProbe = {
-        "httpGet": {
-          "path": config.defaultHealthCheck,
-          "port": containerReqdata.port
-        },
-        "initialDelaySeconds": 120,
-        "timeoutSeconds": 1
-      };
-    containerjson.readinessProbe = {
-        "httpGet": {
-          "path": config.defaultHealthCheck,
-          "port": containerReqdata.port
-        },
-        "initialDelaySeconds": 5,
-        "timeoutSeconds": 1
-      };
-  }
-  if (healthCheck == "tcp") {
-    containerjson.livenessProbe = {
-        "tcpSocket": {
-          "port": containerReqdata.port
-        },
-        "initialDelaySeconds": 120,
-        "timeoutSeconds": 1
-      };
-    containerjson.readinessProbe = {
-        "tcpSocket": {
-          "port": containerReqdata.port
-        },
-        "initialDelaySeconds": 5,
-        "timeoutSeconds": 1
-      };
-  }
+  if (type == "containers") {
+    if (healthCheck == "http") {
+      containerjson.livenessProbe = {
+          "httpGet": {
+            "path": config.defaultHealthCheck,
+            "port": containerReqdata.port
+          },
+          "initialDelaySeconds": 120,
+          "timeoutSeconds": 1
+        };
+      containerjson.readinessProbe = {
+          "httpGet": {
+            "path": config.defaultHealthCheck,
+            "port": containerReqdata.port
+          },
+          "initialDelaySeconds": 5,
+          "timeoutSeconds": 1
+        };
+    }
+    if (healthCheck == "tcp") {
+      containerjson.livenessProbe = {
+          "tcpSocket": {
+            "port": containerReqdata.port
+          },
+          "initialDelaySeconds": 120,
+          "timeoutSeconds": 1
+        };
+      containerjson.readinessProbe = {
+          "tcpSocket": {
+            "port": containerReqdata.port
+          },
+          "initialDelaySeconds": 5,
+          "timeoutSeconds": 1
+        };
+    }
 
-  if (containerReqdata.periodSeconds != null && containerReqdata.periodSeconds != "" && _.isNumber(containerReqdata.periodSeconds)) {
-    //update both
-    containerjson.readinessProbe.periodSeconds = containerReqdata.periodSeconds;
-    containerjson.livenessProbe.periodSeconds = containerReqdata.periodSeconds;
-  }
+    if (containerReqdata.periodSeconds != null && containerReqdata.periodSeconds != "" && _.isNumber(containerReqdata.periodSeconds)) {
+      //update both
+      containerjson.readinessProbe.periodSeconds = containerReqdata.periodSeconds;
+      containerjson.livenessProbe.periodSeconds = containerReqdata.periodSeconds;
+    }
 
-  if (containerReqdata.readinessPeriodSeconds != null && containerReqdata.readinessPeriodSeconds != "" && _.isNumber(containerReqdata.readinessPeriodSeconds)) {
-    containerjson.readinessProbe.periodSeconds = containerReqdata.readinessPeriodSeconds;
-  }
+    if (containerReqdata.readinessPeriodSeconds != null && containerReqdata.readinessPeriodSeconds != "" && _.isNumber(containerReqdata.readinessPeriodSeconds)) {
+      containerjson.readinessProbe.periodSeconds = containerReqdata.readinessPeriodSeconds;
+    }
 
-  if (containerReqdata.livenessPeriodSeconds != null && containerReqdata.livenessPeriodSeconds != "" && _.isNumber(containerReqdata.livenessPeriodSeconds)) {
-    containerjson.livenessProbe.periodSeconds = containerReqdata.livenessPeriodSeconds;
-  }
+    if (containerReqdata.livenessPeriodSeconds != null && containerReqdata.livenessPeriodSeconds != "" && _.isNumber(containerReqdata.livenessPeriodSeconds)) {
+      containerjson.livenessProbe.periodSeconds = containerReqdata.livenessPeriodSeconds;
+    }
 
-  if (containerReqdata.failureThreshold != null && containerReqdata.failureThreshold != "" && _.isNumber(containerReqdata.failureThreshold)) {
-    //update both
-    containerjson.readinessProbe.failureThreshold = containerReqdata.failureThreshold;
-    containerjson.livenessProbe.failureThreshold = containerReqdata.failureThreshold;
-  }
+    if (containerReqdata.failureThreshold != null && containerReqdata.failureThreshold != "" && _.isNumber(containerReqdata.failureThreshold)) {
+      //update both
+      containerjson.readinessProbe.failureThreshold = containerReqdata.failureThreshold;
+      containerjson.livenessProbe.failureThreshold = containerReqdata.failureThreshold;
+    }
 
-  if (containerReqdata.readinessFailureThreshold != null && containerReqdata.readinessFailureThreshold != "" && _.isNumber(containerReqdata.readinessFailureThreshold)) {
-    containerjson.readinessProbe.FailureThreshold = containerReqdata.readinessFailureThreshold;
-  }
+    if (containerReqdata.readinessFailureThreshold != null && containerReqdata.readinessFailureThreshold != "" && _.isNumber(containerReqdata.readinessFailureThreshold)) {
+      containerjson.readinessProbe.FailureThreshold = containerReqdata.readinessFailureThreshold;
+    }
 
-  if (containerReqdata.livenessFailureThreshold != null && containerReqdata.livenessFailureThreshold != "" && _.isNumber(containerReqdata.livenessFailureThreshold)) {
-    containerjson.livenessProbe.FailureThreshold = containerReqdata.livenessFailureThreshold;
-  }
+    if (containerReqdata.livenessFailureThreshold != null && containerReqdata.livenessFailureThreshold != "" && _.isNumber(containerReqdata.livenessFailureThreshold)) {
+      containerjson.livenessProbe.FailureThreshold = containerReqdata.livenessFailureThreshold;
+    }
 
-  if (containerReqdata.timeoutSeconds != null && containerReqdata.timeoutSeconds != "" && _.isNumber(containerReqdata.timeoutSeconds)) {
-    //update both
-    containerjson.readinessProbe.timeoutSeconds = containerReqdata.timeoutSeconds;
-    containerjson.livenessProbe.timeoutSeconds = containerReqdata.timeoutSeconds;
+    if (containerReqdata.timeoutSeconds != null && containerReqdata.timeoutSeconds != "" && _.isNumber(containerReqdata.timeoutSeconds)) {
+      //update both
+      containerjson.readinessProbe.timeoutSeconds = containerReqdata.timeoutSeconds;
+      containerjson.livenessProbe.timeoutSeconds = containerReqdata.timeoutSeconds;
+    }
   }
 
   //handle secret volumes
@@ -258,11 +261,11 @@ exports.handleContainerParams = function (healthCheck, containerReqdata, kubercj
   }
 
   //add basic required template
-  _.merge(kubercjson, {"spec":{"template":{"spec":{containers:[]}}}});
+  _.merge(kubercjson, {"spec":{"template":{"spec":{containers:[], initContainers:[]}}}});
 
   //add container specific json override to kubercjson
   _.merge(containerjson, containerReqdata.k8s);
 
-  kubercjson.spec.template.spec.containers.push(containerjson);
+  kubercjson.spec.template.spec[type].push(containerjson);
 
 };

--- a/api/controllers/deploy/k8sTypes.js
+++ b/api/controllers/deploy/k8sTypes.js
@@ -263,7 +263,10 @@ exports.setrcjson = function (reqdata) {
   //for each container
   if (reqdata.kind.containerSpec) {
     for (var i = 0; i < reqdata.containers.length; i++) {
-      k8sHelper.handleContainerParams(reqdata.healthCheck, reqdata.containers[i], kubeObjJson);
+      k8sHelper.handleContainerParams(reqdata.healthCheck, reqdata.containers[i], kubeObjJson, "containers");
+    }
+    for (var i = 0; _.isArray(reqdata.initContainers) && i < reqdata.initContainers.length; i++) {
+      k8sHelper.handleContainerParams(reqdata.healthCheck, reqdata.initContainers[i], kubeObjJson, "initContainers");
     }
   }
 

--- a/api/controllers/deploy/validate.js
+++ b/api/controllers/deploy/validate.js
@@ -25,6 +25,7 @@ exports.cleanupReqdata = function (reqdata) {
   if (!reqdata.manageServices) {
     delete reqdata.kubesvcjson;
     delete reqdata.containers;
+    delete reqdata.initContainers;
     delete reqdata.serviceType;
   }
   
@@ -148,6 +149,7 @@ exports.validateUpdateIndex = function (reqdata, callback) {
   // replicas: int - number of copys of your container spec you'd like to run -- defaults to 2
   // clusters: int - number of k8sclustes to run your service against -- defaults to all available in the location
   // *containers: {*name: string, *image: string, *port: int, env {name: string, value: string}} -- required
+  // *initContainers: {*name: string, *image: string, *port: int, env {name: string, value: string}} -- optional
   // *user: string - username for token auth to k8s -- required for some clusters
   // *token: string - token for auth to k8s -- required for some clusters
   // namespace: string - defaults to the user, available for override
@@ -298,9 +300,23 @@ exports.validateUpdateIndex = function (reqdata, callback) {
   
   //for each container
   for (var i = 0; i < reqdata.containers.length; i++) {
-    if (reqdata.containers[i].name == "" ||
-    reqdata.containers[i].image == "" || !(_.isNumber(reqdata.containers[i].port) || _.isArray(reqdata.containers[i].port))) {
-      return callback(422, 'Missing required field in containers array: name, image, port');
+    if (reqdata.containers[i].image == "" || !(_.isNumber(reqdata.containers[i].port) || _.isArray(reqdata.containers[i].port))) {
+      return callback(422, 'Missing required field in containers array: image, port');
+    }
+    if (reqdata.containers[i].name == "" || reqdata.containers[i].name == null) {
+      reqdata.containers[i].name = reqdata.name + "-" + _.random(999).toString();
+    }
+  }
+  
+  //for each initContainer
+  if (_.isArray(reqdata.initContainers)) {
+    for (var i = 0; i < reqdata.initContainers.length; i++) {
+      if (reqdata.initContainers[i].image == "" || !(_.isNumber(reqdata.initContainers[i].port) || _.isArray(reqdata.initContainers[i].port))) {
+        return callback(422, 'Missing required field in initContainers array: image, port');
+      }
+      if (reqdata.initContainers[i].name == "" || reqdata.initContainers[i].name == null) {
+        reqdata.initContainers[i].name = reqdata.name + "-" + _.random(999).toString();
+      }
     }
   }
   


### PR DESCRIPTION
This allows initContainers to be specified in deployments.
It also removes the name requirement for containers and initContainers and autogenerates it if missing.

example:
```
curl -H "Content-Type: application/json" -X POST -d '{ "containers": [{
     "image": "treeder/tiny-node:latest",
     "port": 8080}],
     "initContainers":[{"image":"lachlanevenson/k8s-kubectl:latest", "command": ["sh", "-c", "kubectl get pods"], "port": 2000}],
  "name": "example",
  "targetPort": 8080,
  "locations": [{"name": "..."}],
  "token": "...",
  "namespace": "...",
  "replicas": 1
}'
```