### PR TITLE
remove name from container params

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -587,7 +587,6 @@ definitions:
   containerParams:
     type: "object"
     required:
-      - "name"
       - "image"
       - "port"
     properties:


### PR DESCRIPTION
It's no longer required to pass in a name for the container spec, it will be generated automatically when not provided.