### PR TITLE
Remove check that can cause unneeded updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
       - run:
           command: |
-            sudo minikube start --vm-driver=none
+            sudo minikube start --vm-driver=none --kubernetes-version v1.9.4
       - run:
           command: |
             sudo minikube update-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.8.4/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
       - run:
           command: |
-            curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+            curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.26.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
       - run:
           command: |
             sudo minikube start --vm-driver=none --kubernetes-version v1.9.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.8.4/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
       - run:
           command: |
-            curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.26.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+            curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
       - run:
           command: |
             sudo minikube start --vm-driver=none --kubernetes-version v1.9.4

--- a/api/controllers/deploy/k8sCRUD.js
+++ b/api/controllers/deploy/k8sCRUD.js
@@ -131,11 +131,6 @@ const serviceChanged = function (oldSvc, newSvc) {
     svcChanged = true;
     console.log("service port changed", newSvc.metadata.name);
   }
-  
-  if (oldSvc.metadata.hasOwnProperty("annotations") != newSvc.metadata.hasOwnProperty("annotations")) {
-    svcChanged = true;
-    console.log("old || new svc does not contain annotations", newSvc.metadata.name);
-  }
 
   if (!svcChanged && oldSvc.metadata.hasOwnProperty("annotations") && newSvc.metadata.annotations.length != oldSvc.metadata.annotations.length) {
     svcChanged = true;


### PR DESCRIPTION
When no annotations are specified on the service it can fail this check and result in the service unnecessarily getting recreated.