### PR TITLE
fix swagger to allow https for healthCheck

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -369,6 +369,7 @@ definitions:
         enum:
           - "tcp"
           - "http"
+          - "https"
           - "none"
         description: "default is http and based on our standard it will do a health check on the /heath endpoint. At some future date the only option will be http."
         default: "http"
@@ -482,6 +483,7 @@ definitions:
         enum:
           - "tcp"
           - "http"
+          - "https"
           - "none"
         description: "default is http and based on our standard it will do a health check on the /heath endpoint. At some future date the only option will be http."
         default: "http"


### PR DESCRIPTION
This is too restrictive and is preventing `https` health checks.