### PR TITLE
limit version label length to 63 chars

### DIFF
--- a/api/controllers/deploy/validate.js
+++ b/api/controllers/deploy/validate.js
@@ -174,7 +174,7 @@ exports.validateUpdateIndex = function (reqdata, callback) {
   if (!_.has(reqdata, 'version') && _.has(reqdata, 'containers[0].image')) {
     var ver = _.split(reqdata.containers[0].image, ":", 2);
     if (ver.length == 2 && ver[1] != "") {
-      reqdata.version = ver[1];
+      reqdata.version = _.truncate(ver[1],{'length': 63, 'omission': ''});
     }
   }
 


### PR DESCRIPTION
The k8s API already enforces this limit so skipper should truncate when the docker image tag is larger than 63 chars and being used as the version automatically.

Signed-off-by: i845783 <dan.wilson01@sap.com>