### PR TITLE
allow type to default to deployments

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -308,7 +308,6 @@ definitions:
     required:
       - "name"
       - "token"
-      - "type"
     properties:
       name:
         type: "string"


### PR DESCRIPTION
Currently the object api requires the `type` parameter but the code defaults it to `deployments` anyways. This PR relaxes the swagger definition to allow the default to work.